### PR TITLE
Never end up with an empty keywords.cc file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -225,6 +225,7 @@ keywords.cc: keywords.gperf
 		--omit-struct-type --key-positions=1,3,$$ keywords.gperf   \
 		| sed -e 's/#include <ctype.h>/#include "my-ctype.h"/'     \
 		> keywords.cc
+	if [ ! -s keywords.cc ] ; then rm keywords.cc; fi
 
 tags:
 	gtags .


### PR DESCRIPTION
Prevent ending up with an empty keywords.cc file if for some reason gperf fails.
This would lead to a shitload of compiler errors, instead of the more descriptive `file missing' error.