### PR TITLE
Print the correct object when writing to disk.

### DIFF
--- a/db_file.cc
+++ b/db_file.cc
@@ -1090,7 +1090,7 @@ write_db_file(const char *reason)
 	    for (oid = max_oid + 1; oid <= last_oid; oid++) {
 		ng_write_object(oid);
 		if ((oid + 1) % 10000 == 0 || oid == last_oid)
-		    oklog("%s: Done writing %d objects ...\n", reason, last_oid - max_oid);
+		    oklog("%s: Done writing %d objects ...\n", reason, oid + 1);
 	    }
 	    max_oid = last_oid;
 	    last_oid = db_last_used_objid();


### PR DESCRIPTION
Currently, the max_obj is printed to the server log every 10,000 objects. This is correct when the writing completes, but not when actively writing large databases and the count is periodically printed. Small fix here to use oid + 1, which corrects the counter.